### PR TITLE
Use arbitrary element as particle

### DIFF
--- a/src/lib/ConfettiExplosion.svelte
+++ b/src/lib/ConfettiExplosion.svelte
@@ -379,8 +379,8 @@
 {#if isVisible && isValid}
 	<div class="container" style="--floor-height: {stageHeight}px;">
 		{#each particles as { color, degree }}
-			<div class="particle" use:confettiStyles={{ degree }}>
-				<div style="--bgcolor: {color};" />
+			<div class="particle" class:default={$$slots.default !== true} use:confettiStyles={{ degree }}>
+				<div style="--bgcolor: {color};"><slot/></div>
 			</div>
 		{/each}
 	</div>
@@ -419,33 +419,30 @@
 	}
 
 	.particle {
-		animation: x-axis var(--duration-chaos) forwards
-			cubic-bezier(var(--x1), var(--x2), var(--x3), var(--x4));
-
+		animation: x-axis var(--duration-chaos) forwards cubic-bezier(var(--x1), var(--x2), var(--x3), var(--x4));
 		div {
 			position: absolute;
 			top: 0;
 			left: 0;
-
-			animation: y-axis var(--duration-chaos) forwards
-				cubic-bezier(var(--y1), var(--y2), var(--y3), var(--y4));
-
+			animation: y-axis var(--duration-chaos) forwards cubic-bezier(var(--y1), var(--y2), var(--y3), var(--y4));
 			width: var(--width);
 			height: var(--height);
-
+		}
+		&.default {
+		div {
 			&:before {
 				display: block;
-
 				height: 100%;
 				width: 100%;
-
 				content: '';
 				background-color: var(--bgcolor);
-
-				animation: rotation var(--rotation-duration) infinite linear;
-
 				border-radius: var(--border-radius);
+				animation: rotation var(--rotation-duration) infinite linear;
 			}
 		}
+	}
+
+	:global(.particle *:first-child) {
+		animation: rotation var(--rotation-duration) infinite linear;
 	}
 </style>


### PR DESCRIPTION
[REPL](https://svelte.dev/repl/bfbbf8db4c994bc6962ac17d7e8b3e11?version=3.44.2)

DRAFT!!!

I just copy and pasted from my proof of concept REPL above via the GitHub Monaco editor. Need to actually pull down and see if it my edits are correct.

General approach:

Use slots so users can compose particle in the Svelte markup. This allows interesting things like declaring the particle style directly from slot (see last example in REPL). To retain backwards compatibility, use $$slots to detect if arbitrary particle are being used and toggle the `:before` styling accordingly and apply rotation animation to correct element (either `:before` content or slotted element)