### PR TITLE
docs(readme): neodrag -> neoconfetti

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is a monorepo containing the following packages:
 
 ## Roadmap
 
-- [x] @neodrag/svelte
+- [x] @neoconfetti/svelte
 - [ ] @neoconfetti/react
 - [ ] @neoconfetti/vue
 - [ ] @neoconfetti/solid
-- [ ] @neodrag/lit
-- [ ] @neodrag/vanilla
+- [ ] @neoconfetti/lit
+- [ ] @neoconfetti/vanilla


### PR DESCRIPTION
This (most likely caused by partial copying of neodrag's readme) fixes some references to neodrag, by instead pointing them back to neoconfetti.