### PR TITLE
`shouldDestroyAfterDone` -> `destroyAfterDone`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -165,7 +165,7 @@ Width of the stage in pixels. Confetti will only fall within this width.
 <ConfettiExplosion stageWidth={500} />
 ```
 
-### shouldDestroyAfterDone
+### destroyAfterDone
 
 Whether or not destroy all confetti nodes after the `duration` period has passed. By default it destroys all nodes, to free up memory.
 
@@ -176,7 +176,7 @@ Whether or not destroy all confetti nodes after the `duration` period has passed
 **Example:**
 
 ```svelte
-<ConfettiExplosion shouldDestroyAfterDone={false} />
+<ConfettiExplosion destroyAfterDone={false} />
 ```
 
 ## Style Props
@@ -199,7 +199,7 @@ You can specify two style props on the component: `--x` and `--y`. These will sh
 
 This library functions by creating 2 DOM nodes for every single confetti. By default, if the `particlesCount` is set to 150, it will create 300 nodes. This is a lot of nodes. For most devices, these many nodes are not a big issue, but I recommend checking your target devices' performance if you choose to go with a higher number, like 400 or 500.
 
-Also, after the specified `duration`, all the confetti DOM nodes will be destroyed. This is to free up memory. If you wish to keep them around, set `shouldDestroyAfterDone` to `false`.
+Also, after the specified `duration`, all the confetti DOM nodes will be destroyed. This is to free up memory. If you wish to keep them around, set `destroyAfterDone` to `false`.
 
 ## License
 

--- a/packages/core/demo/src/lib/Counter.svelte
+++ b/packages/core/demo/src/lib/Counter.svelte
@@ -22,6 +22,6 @@
 	<div use:confetti={{ destroyAfterDone: false, colors }} />
 {/if}
 
-<!-- <ConfettiExplosion shouldDestroyAfterDone={false} particleCount={4} /> -->
+<!-- <ConfettiExplosion destroyAfterDone={false} particleCount={4} /> -->
 <style>
 </style>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -197,7 +197,7 @@ export const confetti: Action<HTMLElement, ConfettiOptions> = (
 				nodes = createParticleNodes(node, particles);
 			}
 
-			// Dont destroy component if shouldDestroyAfterDone is false now
+			// Dont destroy component if destroyAfterDone is false now
 			if (destroyAfterDone && !newOptions.destroyAfterDone) clearTimeout(timer);
 
 			// Update stageHeight

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -74,7 +74,7 @@ Size of the confetti particles in pixels
 **Example:**
 
 ```svelte
-<div use:confetti={{ particleSize:20 }} />
+<div use:confetti={{ particleSize: 20 }} />
 ```
 
 ### particleShape
@@ -165,7 +165,7 @@ Width of the stage in pixels. Confetti will only fall within this width.
 <div use:confetti={{ stageWidth: 500 }} />
 ```
 
-### shouldDestroyAfterDone
+### destroyAfterDone
 
 Whether or not destroy all confetti nodes after the `duration` period has passed. By default it destroys all nodes, to free up memory.
 


### PR DESCRIPTION
minor changes:
- update old `shouldDestroyAfterDone` references
- adds an extra space after `property:` in `@neoconfetti/svelte`'s README to match other examples