### PR TITLE
fix: add react client directive

### DIFF
--- a/.changeset/stale-ties-play.md
+++ b/.changeset/stale-ties-play.md
@@ -1,0 +1,5 @@
+---
+'@neoconfetti/react': minor
+---
+
+Add React client directive

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { confetti, type ConfettiOptions, type ConfettiParticleShape } from '@neoconfetti/core';
 import { createElement, useEffect, useRef } from 'react';
 


### PR DESCRIPTION
Adds React [`use client` directive](https://react.dev/reference/rsc/use-client#using-third-party-libraries) to make React package compatible with React server components.

Fixes #21 